### PR TITLE
Fix rethrow of JWTError exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.6.2
+
+- Fix rethrow of JWTError exceptions for the method `verify`. Before this change every exception thrown by `verify` always returned JWTUndefinedError
+
 ## 2.6.1
 
 - Adding a `try` version of `decode`, `verify` and `sign`, that simply returns `null` instead of throwing errors

--- a/lib/src/jwt.dart
+++ b/lib/src/jwt.dart
@@ -139,7 +139,9 @@ class JWT {
         return JWT(payload);
       }
     } catch (ex) {
-      if (ex is Error) {
+      if (ex is JWTError) {
+        rethrow;
+      } else if (ex is Error) {
         throw JWTUndefinedError(ex);
       } else {
         rethrow;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_jsonwebtoken
 description: A dart implementation of the famous javascript library 'jsonwebtoken' (JWT).
-version: 2.6.1
+version: 2.6.2
 repository: https://github.com/jonasroussel/dart_jsonwebtoken
 homepage: https://github.com/jonasroussel/dart_jsonwebtoken#readme
 


### PR DESCRIPTION
Fixes #32 

Extend the catch and first check for JWTError:

```
    } catch (ex) {
      if (ex is JWTError) {
        rethrow;
      } else if (ex is Error) {
        throw JWTUndefinedError(ex);
      } else {
        rethrow;
      }
    }
```