### PR TITLE
Add testable date times

### DIFF
--- a/lib/src/jwt.dart
+++ b/lib/src/jwt.dart
@@ -2,12 +2,13 @@ import 'dart:collection';
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:clock/clock.dart';
 import 'package:collection/collection.dart';
 
 import 'algorithms.dart';
 import 'exceptions.dart';
-import 'keys.dart';
 import 'helpers.dart';
+import 'keys.dart';
 
 class JWT {
   /// Verify a token.
@@ -64,7 +65,7 @@ class JWT {
           final exp = DateTime.fromMillisecondsSinceEpoch(
             payload['exp'] * 1000,
           );
-          if (exp.isBefore(DateTime.now())) {
+          if (exp.isBefore(clock.now())) {
             throw JWTExpiredException();
           }
         }
@@ -74,7 +75,7 @@ class JWT {
           final nbf = DateTime.fromMillisecondsSinceEpoch(
             payload['nbf'] * 1000,
           );
-          if (nbf.isAfter(DateTime.now())) {
+          if (nbf.isAfter(clock.now())) {
             throw JWTNotActiveException();
           }
         }
@@ -87,7 +88,7 @@ class JWT {
           final iat = DateTime.fromMillisecondsSinceEpoch(
             payload['iat'] * 1000,
           );
-          if (!iat.isAtSameMomentAs(DateTime.now())) {
+          if (!iat.isAtSameMomentAs(clock.now())) {
             throw JWTInvalidException('invalid issue at');
           }
         }
@@ -265,12 +266,12 @@ class JWT {
         try {
           payload = Map<String, dynamic>.from(payload);
 
-          if (!noIssueAt) payload['iat'] = secondsSinceEpoch(DateTime.now());
+          if (!noIssueAt) payload['iat'] = secondsSinceEpoch(clock.now());
           if (expiresIn != null) {
-            payload['exp'] = secondsSinceEpoch(DateTime.now().add(expiresIn));
+            payload['exp'] = secondsSinceEpoch(clock.now().add(expiresIn));
           }
           if (notBefore != null) {
-            payload['nbf'] = secondsSinceEpoch(DateTime.now().add(notBefore));
+            payload['nbf'] = secondsSinceEpoch(clock.now().add(notBefore));
           }
           if (audience != null) payload['aud'] = audience!.toJson();
           if (subject != null) payload['sub'] = subject;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   convert: ^3.1.1
   collection: ^1.17.1
   ed25519_edwards: ^0.3.1
+  clock: ^1.1.1
 
 dev_dependencies:
   lints: ^2.1.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,5 +20,6 @@ dependencies:
   clock: ^1.1.1
 
 dev_dependencies:
+  fake_async: ^1.3.1
   lints: ^2.1.1
   test: ^1.24.6

--- a/test/header_test.dart
+++ b/test/header_test.dart
@@ -1,0 +1,50 @@
+import 'package:clock/clock.dart';
+import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
+import 'package:fake_async/fake_async.dart';
+import 'package:test/test.dart';
+
+final hsKey = SecretKey('secret passphrase');
+
+void main() {
+  group("JWT Header", () {
+    //--------------------//
+    //  Expiration (exp)  //
+    //--------------------//
+    group('exp', () {
+      test('should be expired', () {
+        final duration = Duration(hours: 1);
+        final token = JWT({'foo': 'bar'}).sign(hsKey, expiresIn: duration);
+
+        fakeAsync((async) {
+          async.elapse(duration);
+          expect(
+            () => JWT.verify(token, hsKey),
+            throwsA(isA<JWTExpiredException>()),
+          );
+        });
+      });
+
+      test('should be still valid', () {
+        withClock(
+          Clock.fixed(DateTime(2023)),
+          () {
+            final duration = Duration(hours: 1);
+            final token = JWT({'foo': 'bar'}).sign(hsKey, expiresIn: duration);
+
+            fakeAsync((async) {
+              async.elapse(Duration(minutes: 30));
+              expect(
+                JWT.verify(token, hsKey).payload,
+                equals({
+                  'foo': 'bar',
+                  'iat': 1672527600,
+                  'exp': 1672531200,
+                }),
+              );
+            });
+          },
+        );
+      });
+    });
+  });
+}

--- a/test/verify_test.dart
+++ b/test/verify_test.dart
@@ -1,8 +1,6 @@
 import 'dart:convert';
 
-import 'package:clock/clock.dart';
 import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
-import 'package:fake_async/fake_async.dart';
 import 'package:test/test.dart';
 
 final hsKey = SecretKey('secret passphrase');
@@ -196,47 +194,6 @@ void main() {
 
         expect(jwt, isNotNull);
         expect(jwt?.payload, equals({'foo': 'bar'}));
-      });
-    });
-
-    //-------//
-    //  exp  //
-    //-------//
-    group('.verify exp', () {
-      test('should be expired', () {
-        final duration = Duration(hours: 1);
-        final token = JWT({'foo': 'bar'}).sign(hsKey, expiresIn: duration);
-        fakeAsync((async) {
-          async.elapse(duration);
-          expect(
-            () => JWT.verify(token, hsKey),
-            throwsA(isA<JWTExpiredException>()),
-          );
-        });
-      });
-
-      test('should be still valid', () {
-        withClock(
-          Clock.fixed(DateTime(2023)),
-          () {
-            final token = JWT({'foo': 'bar'}).sign(
-              hsKey,
-              expiresIn: Duration(hours: 1),
-            );
-            fakeAsync((async) {
-              async.elapse(Duration(minutes: 30));
-              final jwt = JWT.verify(token, hsKey);
-              expect(
-                jwt.payload,
-                equals({
-                  'foo': 'bar',
-                  'iat': 1672542000,
-                  'exp': 1672545600,
-                }),
-              );
-            });
-          },
-        );
       });
     });
   });

--- a/test/verify_test.dart
+++ b/test/verify_test.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 
+import 'package:clock/clock.dart';
 import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:test/test.dart';
 
 final hsKey = SecretKey('secret passphrase');
@@ -194,6 +196,47 @@ void main() {
 
         expect(jwt, isNotNull);
         expect(jwt?.payload, equals({'foo': 'bar'}));
+      });
+    });
+
+    //-------//
+    //  exp  //
+    //-------//
+    group('.verify exp', () {
+      test('should be expired', () {
+        final duration = Duration(hours: 1);
+        final token = JWT({'foo': 'bar'}).sign(hsKey, expiresIn: duration);
+        fakeAsync((async) {
+          async.elapse(duration);
+          expect(
+            () => JWT.verify(token, hsKey),
+            throwsA(isA<JWTExpiredException>()),
+          );
+        });
+      });
+
+      test('should be still valid', () {
+        withClock(
+          Clock.fixed(DateTime(2023)),
+          () {
+            final token = JWT({'foo': 'bar'}).sign(
+              hsKey,
+              expiresIn: Duration(hours: 1),
+            );
+            fakeAsync((async) {
+              async.elapse(Duration(minutes: 30));
+              final jwt = JWT.verify(token, hsKey);
+              expect(
+                jwt.payload,
+                equals({
+                  'foo': 'bar',
+                  'iat': 1672542000,
+                  'exp': 1672545600,
+                }),
+              );
+            });
+          },
+        );
       });
     });
   });


### PR DESCRIPTION
## Description

This PR replaces untestable `DateTime.now()` with `clock.now()` from [pkg:clock](https://pub.dev/packages/clock).
With this change, the package and the clients of the package could be testing token date times using [pkg:fake_async](https://pub.dev/packages/fake_async).

And the best part, this change doesn't add breaking changes or change the current behaviors!

Here's a sample of testing an expired token:

```dart
import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
import 'package:fake_async/fake_async.dart';
import 'package:test/test.dart';

void main() {
  test('should expires when `expiresIn` duration is elapsed', () {
    final secretKey = SecretKey('secret_key');
    final jwt = JWT({'foo': 'bar'});
    final duration = Duration(hours: 1);
    fakeAsync((async) {
      final token = jwt.sign(secretKey, expiresIn: duration);
      async.elapse(duration);
      expect(
        () => JWT.verify(token, secretKey),
        throwsA(isA<JWTExpiredException>()),
      );
    });
  });
}

```
Note: clock and fake_async are published by Dart Team:
- https://pub.dev/publishers/tools.dart.dev/packages
- https://pub.dev/publishers/dart.dev/packages
