### PR TITLE
feat: add support for base64 encoded secrets

### DIFF
--- a/lib/src/algorithms.dart
+++ b/lib/src/algorithms.dart
@@ -147,7 +147,12 @@ class HMACAlgorithm extends JWTAlgorithm {
     assert(key is SecretKey, 'key must be a SecretKey');
     final secretKey = key as SecretKey;
 
-    final hmac = Hmac(_getHash(name), utf8.encode(secretKey.key));
+    final hmac = Hmac(
+      _getHash(name),
+      secretKey.isBase64Encoded
+          ? base64Decode(secretKey.key)
+          : utf8.encode(secretKey.key),
+    );
 
     return Uint8List.fromList(hmac.convert(body).bytes);
   }

--- a/lib/src/keys.dart
+++ b/lib/src/keys.dart
@@ -11,8 +11,9 @@ abstract class JWTKey {}
 /// For HMAC algorithms
 class SecretKey extends JWTKey {
   String key;
+  bool isBase64Encoded;
 
-  SecretKey(this.key);
+  SecretKey(this.key, {this.isBase64Encoded = false});
 }
 
 /// For RSA algorithm, in sign method


### PR DESCRIPTION
## Description

This pull request adds support for base64-encoded secrets within the HMAC algorithm in the library. This enhancement enables users to specify whether their secret key is base64-encoded by passing the optional named parameter isBase64Encoded. This functionality is especially relevant when working with systems that distribute secret keys in base64-encoded formats, a common scenario evidenced by the presence of such an option on the [jwt.io](https://jwt.io/) platform.

![image](https://github.com/jonasroussel/dart_jsonwebtoken/assets/20880200/0cd9d468-778f-490b-9ce4-6dfc753683f9)

The need for this change arose while verifying a base64 encoded secret key provided by the ThingsBoard platform, which signs its tokens with such a [key](https://thingsboard.io/docs/user-guide/install/config/#security-parameters). If there is an alternative method to handle base64 encoded secrets that I have overlooked, I welcome feedback. Please guide me to the correct approach or feel free to close this pull request.

## Changes made:
- A new boolean field `isBase64Encoded` has been introduced in the `SecretKey` class, defaulting to false.
- The `HMACAlgorithm` class has been updated to decode the base64 secret key when `isBase64Encoded` is set to true. This decoded key is then used to generate the HMAC for token signing or verification.
- Backward compatibility is maintained, as the existing behavior persists when the `isBase64Encoded` parameter is not set.

## Testing:
For verification purposes, here is a simple JWT token and its corresponding secret:

https://jwt.io/#debugger-io?token=eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QGV4YW1wbGUuY29tIiwiaWF0IjoxNzEyMTI0Nzg3LCJleHAiOjE4MjIxMzM3ODd9.vCVkO4q5mKr1QG3yqCNCP9oh0byb7fPe-snOPn7XTLKWiEk-19reuTF4iIzvjxCAHcmQ7bYUf6vOIbPaXP1aIg

secret: `test` (base64 encoded)