### PR TITLE
Added support for PSS alogrithm varations

### DIFF
--- a/lib/src/algorithms.dart
+++ b/lib/src/algorithms.dart
@@ -208,9 +208,23 @@ class RSAAlgorithm extends JWTAlgorithm {
     );
 
     if (algorithm == 'PSS') {
+      int byteValue = 32;
       final random = _random ?? Random.secure();
+      switch (name) {
+        case 'PS256':
+          byteValue = 32;
+          break;
+        case 'PS384':
+          byteValue = 48;
+          break;
+        case 'PS512':
+          byteValue = 64;
+          break;
+        default:
+          byteValue = 32;
+      }
       final salt = Uint8List.fromList(
-        List.generate(32, (_) => random.nextInt(256)),
+        List.generate(byteValue, (_) => random.nextInt(256)),
       );
 
       params = pc.ParametersWithSalt(
@@ -244,15 +258,29 @@ class RSAAlgorithm extends JWTAlgorithm {
       );
 
       if (algorithm == 'PSS') {
+        int byteValue = 32;
         final secureRandom = pc.SecureRandom('Fortuna');
         final random = Random.secure();
-        final seed = List.generate(32, (_) => random.nextInt(256));
+        switch (algorithm) {
+          case 'PS256':
+            byteValue = 34;
+            break;
+          case 'PS384':
+            byteValue = 48;
+            break;
+          case 'PS512':
+            byteValue = 64;
+            break;
+          default:
+            byteValue = 34;
+        }
+        final seed = List.generate(byteValue, (_) => random.nextInt(256));
         secureRandom.seed(pc.KeyParameter(Uint8List.fromList(seed)));
 
         params = pc.ParametersWithSaltConfiguration(
           params,
           secureRandom,
-          32,
+          byteValue,
         );
       }
 

--- a/lib/src/algorithms.dart
+++ b/lib/src/algorithms.dart
@@ -263,7 +263,7 @@ class RSAAlgorithm extends JWTAlgorithm {
         final random = Random.secure();
         switch (algorithm) {
           case 'PS256':
-            byteValue = 34;
+            byteValue = 32;
             break;
           case 'PS384':
             byteValue = 48;
@@ -272,7 +272,7 @@ class RSAAlgorithm extends JWTAlgorithm {
             byteValue = 64;
             break;
           default:
-            byteValue = 34;
+            byteValue = 32;
         }
         final seed = List.generate(byteValue, (_) => random.nextInt(256));
         secureRandom.seed(pc.KeyParameter(Uint8List.fromList(seed)));

--- a/lib/src/algorithms.dart
+++ b/lib/src/algorithms.dart
@@ -261,7 +261,7 @@ class RSAAlgorithm extends JWTAlgorithm {
         int byteValue = 32;
         final secureRandom = pc.SecureRandom('Fortuna');
         final random = Random.secure();
-        switch (algorithm) {
+        switch (name) {
           case 'PS256':
             byteValue = 32;
             break;

--- a/lib/src/algorithms.dart
+++ b/lib/src/algorithms.dart
@@ -208,23 +208,9 @@ class RSAAlgorithm extends JWTAlgorithm {
     );
 
     if (algorithm == 'PSS') {
-      int byteValue = 32;
       final random = _random ?? Random.secure();
-      switch (name) {
-        case 'PS256':
-          byteValue = 32;
-          break;
-        case 'PS384':
-          byteValue = 48;
-          break;
-        case 'PS512':
-          byteValue = 64;
-          break;
-        default:
-          byteValue = 32;
-      }
       final salt = Uint8List.fromList(
-        List.generate(byteValue, (_) => random.nextInt(256)),
+        List.generate(_getSaltLength(name), (_) => random.nextInt(256)),
       );
 
       params = pc.ParametersWithSalt(
@@ -258,29 +244,10 @@ class RSAAlgorithm extends JWTAlgorithm {
       );
 
       if (algorithm == 'PSS') {
-        int byteValue = 32;
-        final secureRandom = pc.SecureRandom('Fortuna');
-        final random = Random.secure();
-        switch (name) {
-          case 'PS256':
-            byteValue = 32;
-            break;
-          case 'PS384':
-            byteValue = 48;
-            break;
-          case 'PS512':
-            byteValue = 64;
-            break;
-          default:
-            byteValue = 32;
-        }
-        final seed = List.generate(byteValue, (_) => random.nextInt(256));
-        secureRandom.seed(pc.KeyParameter(Uint8List.fromList(seed)));
-
         params = pc.ParametersWithSaltConfiguration(
           params,
-          secureRandom,
-          byteValue,
+          pc.SecureRandom('Fortuna'),
+          _getSaltLength(name),
         );
       }
 
@@ -293,6 +260,7 @@ class RSAAlgorithm extends JWTAlgorithm {
 
       return signer.verifySignature(msg, sign);
     } catch (ex) {
+      print(ex);
       return false;
     }
   }
@@ -325,6 +293,19 @@ class RSAAlgorithm extends JWTAlgorithm {
         return 'PSS';
       default:
         throw ArgumentError.value(name, 'name', 'unknown algorithm name');
+    }
+  }
+
+  int _getSaltLength(String name) {
+    switch (name) {
+      case 'PS256':
+        return 32;
+      case 'PS384':
+        return 48;
+      case 'PS512':
+        return 64;
+      default:
+        return 32;
     }
   }
 }

--- a/test/sign_test.dart
+++ b/test/sign_test.dart
@@ -194,7 +194,7 @@ void main() {
 
         final expectedToken = 'eyJhbGciOiJQUzM4NCIsInR5cCI6IkpXVCJ9' +
             '.eyJmb28iOiJiYXIifQ' +
-            '.PhknpMzuv34E_6T5wl7aLu3jRh0meVdYZzvfCdWhZAPYYYcFKQYmW2PbUYUQ-uzw45y9_bwElKiGD0hcW8fXuZBcx4lg3EX96mE7AzjYBVIS-lK2Xyd8KcC2sx7PjRlfSL_BQOXCNz3JmGNPJCaioMOTl0ha-jFsV_9mgUiK_--TQpU731ebIYaM4XS8rJxW-zthrGlgutAs2vGyLLgOOkome_ELBd6tcI3ip-Q58wK603PDnYo3FtyP_JfL4vtuRwQs9BEU0Y3Awfm0cuQaXf52sdQTTnwm0_E_dn-sPT8Q8F3UpPoOGPhFncxXpr2vUk_6_X_fdOxtkOVsPunxg-h9eVzfZEldrec-DRAKcyKHrycOuk8HBhcyCFjvw0Mjhe9g6urH-LBZQ1Hikwrzcp0B-xa9uQ801EtuanQGOqTPM1zqEmhQGJLIDtqaen9RD7gK18f0fqnWbIKUMEfkMQRm3tEmLy8HX2P0C3H64Qq3iXPTtk8lX_e1nN20WEyo';
+            '.dsTJLDMHPG39hBvTWrRAaSFJjRZ8oy5mTPi4EXfgzHj95UznA_LTJwS_T_BCPZ0nU3xjdybyFo7KQU07npShBt4h-1_qsD_VtHZpRFNrzLj9M2mJ40AdQGr_br4itcTotjycy3D6OCCbibHll4zokklRqdz5GL1ofqlMV4a07UzaaDngMXtd88rRclPYR2Z6tW9B_YLqQa_zIRm2kjt2_UuyC2vS70NpbtCWGnB07xLWfTvTLeTwTMfmWcemTEmIq6c-yLSdhenvhJbnKaIDYp7XLqvQPg-cJItAefE-K0aOB1-dji_VLL1GDn1wdkqMaou3ZJ3c8-iSW1uxmW7XSA';
 
         expect(token, equals(expectedToken));
       });
@@ -203,7 +203,7 @@ void main() {
 
         final expectedToken = 'eyJhbGciOiJQUzUxMiIsInR5cCI6IkpXVCJ9' +
             '.eyJmb28iOiJiYXIifQ' +
-            '.W5mq7RcMNnedPPjid7Rmt4TTBrZbIVwNdvhQvhzlraTlFc7cGfOK8vj_ZooqWkbaixD9pt1MNv18Tfi-Z7kgbHbM-1jwC558DCdkMsSNZbsMoqV6DjyJV0QvZ9kAdce-Nkowjj-aUhQcSk86tUFCYG-ekEoRcNsuyXu6sWxeKJORWofzfgNP_oVaSSMn_l-IVizc1H8uTEoYO7G6hzoyobzyROqn5fu4RosxfHPcYVP6fSxdLt2UZExfb-zOqyplVOYwh25fOoiPFz97-wwjXqy2c2QNgxLysHaNQ4VImU55fRKxRe4NHzyDMjExxdZZ0y1z3OVNt29a5ARWOrtXCfDYy8r7sDhFQb7eAblrLnFkTN4Te7MPwGKzMLS2auFHPL5A3dAXAQchHEcESVWYGyQFTYr1GD2IioOsLqDDtyHQKEz9rDzMnitTWd3qMxbl4P6zklsm9_VV9Mrza3zwtVh6yCE5J7F0ZewVKg_0HA2S077slLfoJFUsM-BJ_hhM';
+            '.qxSGiQw_OxrmC5AXJB8-06BFjSUyzZv8qK6ClvFHYAh57RrDHBcX-Msly0woDYgxc4ZMTnqJcncbDkA6caXil6e-3q5HPbcjU__tHaCWVglfM9A0ckObE_LL_Q6eJd7aYUFRCvgJ1bmjnT8KUmIMs5dM0PIlAgcVDiBdHkrEa4i8cdl9wd0W3xVOrbSuXc3NVAt5kSHdrC7dK5Zmx6aYmrbD346W_Kg-JmZwJwUzq8BPlbOaRbIg1OkkEtGV2SvI552zbcR0dR_1tB26cIn7G2CIKN77qULVRwZHpzZbM9HzL5edu4U8OzijyRfA1bWLfPNEgy0VYw6zskzReFRCiA';
 
         expect(token, equals(expectedToken));
       });

--- a/test/sign_test.dart
+++ b/test/sign_test.dart
@@ -194,7 +194,7 @@ void main() {
 
         final expectedToken = 'eyJhbGciOiJQUzM4NCIsInR5cCI6IkpXVCJ9' +
             '.eyJmb28iOiJiYXIifQ' +
-            '.KVuzcv9rBYCcQMPPjis1sAuYy4jSrustwT-gRqx1P0P1Q43ku-f3tXcFluYUJO6r6gVzV_OmsffxSGgk7QEc8SFqoAWO25QaGYAKqjqeKUL-57d8NQSFLSEdJhrNZ1z6jQoTmkVxgKi5EqDV0DbAt4d6yBd8I2QFLS9G1QNa3XtziwJezrVS-Z6ccIesoZwzczebiHnEmG8DPDcv5Y8Jb_nnmY2w8AQ_wVU1AkiUkTEZ1lDzYB_YUxCzUzSmqrLHIAHsUoV5lt3-hzOJl9Mp5f4ik0QtqQ76NaUZoXrVnTaMpES1bHwpGZcJQEu3igzm6RjI8-kkfcpUsG4Nwsx4TQ';
+            '.PhknpMzuv34E_6T5wl7aLu3jRh0meVdYZzvfCdWhZAPYYYcFKQYmW2PbUYUQ-uzw45y9_bwElKiGD0hcW8fXuZBcx4lg3EX96mE7AzjYBVIS-lK2Xyd8KcC2sx7PjRlfSL_BQOXCNz3JmGNPJCaioMOTl0ha-jFsV_9mgUiK_--TQpU731ebIYaM4XS8rJxW-zthrGlgutAs2vGyLLgOOkome_ELBd6tcI3ip-Q58wK603PDnYo3FtyP_JfL4vtuRwQs9BEU0Y3Awfm0cuQaXf52sdQTTnwm0_E_dn-sPT8Q8F3UpPoOGPhFncxXpr2vUk_6_X_fdOxtkOVsPunxg-h9eVzfZEldrec-DRAKcyKHrycOuk8HBhcyCFjvw0Mjhe9g6urH-LBZQ1Hikwrzcp0B-xa9uQ801EtuanQGOqTPM1zqEmhQGJLIDtqaen9RD7gK18f0fqnWbIKUMEfkMQRm3tEmLy8HX2P0C3H64Qq3iXPTtk8lX_e1nN20WEyo';
 
         expect(token, equals(expectedToken));
       });
@@ -203,7 +203,7 @@ void main() {
 
         final expectedToken = 'eyJhbGciOiJQUzUxMiIsInR5cCI6IkpXVCJ9' +
             '.eyJmb28iOiJiYXIifQ' +
-            '.Pfgxx9l4863v2pEs4uZgR6WJ9HHu0hPO9I6JkiSSJ8idsl9hpW6iuHmVvRskvbqVxKcZi1EQZ_9p-JDRB5JZCVn73BRencZiV_MDc0pDwOqd8Y7RmYiG_V_yfE_djJIpk9vEcpSJuC3Ow6uesNthcyG1CRU41f_qbUaNdg4AYucpvVxEKVzwss94Iq4bqIFy56pKl6HfwZZx1ShlefrbIPVpZgE4TPGwoR2GxMc0zuMAea3skHhRC02TZNiFZJ6zqBUolNrWxIoXNFyeLnjZgi6IHJ0jClym54HT8r_hOnf6j5J8M0j7xUmUZD7WDSdLw0pJU8VsCBtgec5Bk9HQiQ';
+            '.W5mq7RcMNnedPPjid7Rmt4TTBrZbIVwNdvhQvhzlraTlFc7cGfOK8vj_ZooqWkbaixD9pt1MNv18Tfi-Z7kgbHbM-1jwC558DCdkMsSNZbsMoqV6DjyJV0QvZ9kAdce-Nkowjj-aUhQcSk86tUFCYG-ekEoRcNsuyXu6sWxeKJORWofzfgNP_oVaSSMn_l-IVizc1H8uTEoYO7G6hzoyobzyROqn5fu4RosxfHPcYVP6fSxdLt2UZExfb-zOqyplVOYwh25fOoiPFz97-wwjXqy2c2QNgxLysHaNQ4VImU55fRKxRe4NHzyDMjExxdZZ0y1z3OVNt29a5ARWOrtXCfDYy8r7sDhFQb7eAblrLnFkTN4Te7MPwGKzMLS2auFHPL5A3dAXAQchHEcESVWYGyQFTYr1GD2IioOsLqDDtyHQKEz9rDzMnitTWd3qMxbl4P6zklsm9_VV9Mrza3zwtVh6yCE5J7F0ZewVKg_0HA2S077slLfoJFUsM-BJ_hhM';
 
         expect(token, equals(expectedToken));
       });

--- a/test/verify_test.dart
+++ b/test/verify_test.dart
@@ -218,7 +218,7 @@ void main() {
       test('.verify PS384', () {
         final token = 'eyJhbGciOiJQUzM4NCIsInR5cCI6IkpXVCJ9' +
             '.eyJmb28iOiJiYXIifQ' +
-            '.PhknpMzuv34E_6T5wl7aLu3jRh0meVdYZzvfCdWhZAPYYYcFKQYmW2PbUYUQ-uzw45y9_bwElKiGD0hcW8fXuZBcx4lg3EX96mE7AzjYBVIS-lK2Xyd8KcC2sx7PjRlfSL_BQOXCNz3JmGNPJCaioMOTl0ha-jFsV_9mgUiK_--TQpU731ebIYaM4XS8rJxW-zthrGlgutAs2vGyLLgOOkome_ELBd6tcI3ip-Q58wK603PDnYo3FtyP_JfL4vtuRwQs9BEU0Y3Awfm0cuQaXf52sdQTTnwm0_E_dn-sPT8Q8F3UpPoOGPhFncxXpr2vUk_6_X_fdOxtkOVsPunxg-h9eVzfZEldrec-DRAKcyKHrycOuk8HBhcyCFjvw0Mjhe9g6urH-LBZQ1Hikwrzcp0B-xa9uQ801EtuanQGOqTPM1zqEmhQGJLIDtqaen9RD7gK18f0fqnWbIKUMEfkMQRm3tEmLy8HX2P0C3H64Qq3iXPTtk8lX_e1nN20WEyo';
+            '.dsTJLDMHPG39hBvTWrRAaSFJjRZ8oy5mTPi4EXfgzHj95UznA_LTJwS_T_BCPZ0nU3xjdybyFo7KQU07npShBt4h-1_qsD_VtHZpRFNrzLj9M2mJ40AdQGr_br4itcTotjycy3D6OCCbibHll4zokklRqdz5GL1ofqlMV4a07UzaaDngMXtd88rRclPYR2Z6tW9B_YLqQa_zIRm2kjt2_UuyC2vS70NpbtCWGnB07xLWfTvTLeTwTMfmWcemTEmIq6c-yLSdhenvhJbnKaIDYp7XLqvQPg-cJItAefE-K0aOB1-dji_VLL1GDn1wdkqMaou3ZJ3c8-iSW1uxmW7XSA';
 
         final jwt = JWT.tryVerify(token, rsaKey);
 
@@ -228,7 +228,7 @@ void main() {
       test('.verify PS512', () {
         final token = 'eyJhbGciOiJQUzUxMiIsInR5cCI6IkpXVCJ9' +
             '.eyJmb28iOiJiYXIifQ' +
-            '.W5mq7RcMNnedPPjid7Rmt4TTBrZbIVwNdvhQvhzlraTlFc7cGfOK8vj_ZooqWkbaixD9pt1MNv18Tfi-Z7kgbHbM-1jwC558DCdkMsSNZbsMoqV6DjyJV0QvZ9kAdce-Nkowjj-aUhQcSk86tUFCYG-ekEoRcNsuyXu6sWxeKJORWofzfgNP_oVaSSMn_l-IVizc1H8uTEoYO7G6hzoyobzyROqn5fu4RosxfHPcYVP6fSxdLt2UZExfb-zOqyplVOYwh25fOoiPFz97-wwjXqy2c2QNgxLysHaNQ4VImU55fRKxRe4NHzyDMjExxdZZ0y1z3OVNt29a5ARWOrtXCfDYy8r7sDhFQb7eAblrLnFkTN4Te7MPwGKzMLS2auFHPL5A3dAXAQchHEcESVWYGyQFTYr1GD2IioOsLqDDtyHQKEz9rDzMnitTWd3qMxbl4P6zklsm9_VV9Mrza3zwtVh6yCE5J7F0ZewVKg_0HA2S077slLfoJFUsM-BJ_hhM';
+            '.qxSGiQw_OxrmC5AXJB8-06BFjSUyzZv8qK6ClvFHYAh57RrDHBcX-Msly0woDYgxc4ZMTnqJcncbDkA6caXil6e-3q5HPbcjU__tHaCWVglfM9A0ckObE_LL_Q6eJd7aYUFRCvgJ1bmjnT8KUmIMs5dM0PIlAgcVDiBdHkrEa4i8cdl9wd0W3xVOrbSuXc3NVAt5kSHdrC7dK5Zmx6aYmrbD346W_Kg-JmZwJwUzq8BPlbOaRbIg1OkkEtGV2SvI552zbcR0dR_1tB26cIn7G2CIKN77qULVRwZHpzZbM9HzL5edu4U8OzijyRfA1bWLfPNEgy0VYw6zskzReFRCiA';
 
         final jwt = JWT.tryVerify(token, rsaKey);
 

--- a/test/verify_test.dart
+++ b/test/verify_test.dart
@@ -218,7 +218,7 @@ void main() {
       test('.verify PS384', () {
         final token = 'eyJhbGciOiJQUzM4NCIsInR5cCI6IkpXVCJ9' +
             '.eyJmb28iOiJiYXIifQ' +
-            '.KVuzcv9rBYCcQMPPjis1sAuYy4jSrustwT-gRqx1P0P1Q43ku-f3tXcFluYUJO6r6gVzV_OmsffxSGgk7QEc8SFqoAWO25QaGYAKqjqeKUL-57d8NQSFLSEdJhrNZ1z6jQoTmkVxgKi5EqDV0DbAt4d6yBd8I2QFLS9G1QNa3XtziwJezrVS-Z6ccIesoZwzczebiHnEmG8DPDcv5Y8Jb_nnmY2w8AQ_wVU1AkiUkTEZ1lDzYB_YUxCzUzSmqrLHIAHsUoV5lt3-hzOJl9Mp5f4ik0QtqQ76NaUZoXrVnTaMpES1bHwpGZcJQEu3igzm6RjI8-kkfcpUsG4Nwsx4TQ';
+            '.PhknpMzuv34E_6T5wl7aLu3jRh0meVdYZzvfCdWhZAPYYYcFKQYmW2PbUYUQ-uzw45y9_bwElKiGD0hcW8fXuZBcx4lg3EX96mE7AzjYBVIS-lK2Xyd8KcC2sx7PjRlfSL_BQOXCNz3JmGNPJCaioMOTl0ha-jFsV_9mgUiK_--TQpU731ebIYaM4XS8rJxW-zthrGlgutAs2vGyLLgOOkome_ELBd6tcI3ip-Q58wK603PDnYo3FtyP_JfL4vtuRwQs9BEU0Y3Awfm0cuQaXf52sdQTTnwm0_E_dn-sPT8Q8F3UpPoOGPhFncxXpr2vUk_6_X_fdOxtkOVsPunxg-h9eVzfZEldrec-DRAKcyKHrycOuk8HBhcyCFjvw0Mjhe9g6urH-LBZQ1Hikwrzcp0B-xa9uQ801EtuanQGOqTPM1zqEmhQGJLIDtqaen9RD7gK18f0fqnWbIKUMEfkMQRm3tEmLy8HX2P0C3H64Qq3iXPTtk8lX_e1nN20WEyo';
 
         final jwt = JWT.tryVerify(token, rsaKey);
 
@@ -228,7 +228,7 @@ void main() {
       test('.verify PS512', () {
         final token = 'eyJhbGciOiJQUzUxMiIsInR5cCI6IkpXVCJ9' +
             '.eyJmb28iOiJiYXIifQ' +
-            '.Pfgxx9l4863v2pEs4uZgR6WJ9HHu0hPO9I6JkiSSJ8idsl9hpW6iuHmVvRskvbqVxKcZi1EQZ_9p-JDRB5JZCVn73BRencZiV_MDc0pDwOqd8Y7RmYiG_V_yfE_djJIpk9vEcpSJuC3Ow6uesNthcyG1CRU41f_qbUaNdg4AYucpvVxEKVzwss94Iq4bqIFy56pKl6HfwZZx1ShlefrbIPVpZgE4TPGwoR2GxMc0zuMAea3skHhRC02TZNiFZJ6zqBUolNrWxIoXNFyeLnjZgi6IHJ0jClym54HT8r_hOnf6j5J8M0j7xUmUZD7WDSdLw0pJU8VsCBtgec5Bk9HQiQ';
+            '.W5mq7RcMNnedPPjid7Rmt4TTBrZbIVwNdvhQvhzlraTlFc7cGfOK8vj_ZooqWkbaixD9pt1MNv18Tfi-Z7kgbHbM-1jwC558DCdkMsSNZbsMoqV6DjyJV0QvZ9kAdce-Nkowjj-aUhQcSk86tUFCYG-ekEoRcNsuyXu6sWxeKJORWofzfgNP_oVaSSMn_l-IVizc1H8uTEoYO7G6hzoyobzyROqn5fu4RosxfHPcYVP6fSxdLt2UZExfb-zOqyplVOYwh25fOoiPFz97-wwjXqy2c2QNgxLysHaNQ4VImU55fRKxRe4NHzyDMjExxdZZ0y1z3OVNt29a5ARWOrtXCfDYy8r7sDhFQb7eAblrLnFkTN4Te7MPwGKzMLS2auFHPL5A3dAXAQchHEcESVWYGyQFTYr1GD2IioOsLqDDtyHQKEz9rDzMnitTWd3qMxbl4P6zklsm9_VV9Mrza3zwtVh6yCE5J7F0ZewVKg_0HA2S077slLfoJFUsM-BJ_hhM';
 
         final jwt = JWT.tryVerify(token, rsaKey);
 


### PR DESCRIPTION
Ammended the sign and verify functions to support PSS algorithm variations. Resolving a bug causing invalid signature response due to incorrect byte size used during sign process. Support now added for PS256/384/512 and corresponding byte size. 

https://github.com/jonasroussel/dart_jsonwebtoken/issues/58

Credit to user613 for identifing the issue.