### PR TITLE
Add Missing Base64 Padding Case in Helpers

### DIFF
--- a/lib/src/helpers.dart
+++ b/lib/src/helpers.dart
@@ -4,19 +4,22 @@ import 'dart:typed_data';
 final jsonBase64 = json.fuse(utf8.fuse(base64Url));
 
 String base64Unpadded(String value) {
+  if (value.endsWith('===')) return value.substring(0, value.length - 3);
   if (value.endsWith('==')) return value.substring(0, value.length - 2);
   if (value.endsWith('=')) return value.substring(0, value.length - 1);
   return value;
 }
 
 String base64Padded(String value) {
-  final lenght = value.length;
+  final length = value.length;
 
-  switch (lenght % 4) {
+  switch (length % 4) {
+    case 1:
+      return value.padRight(length + 3, '=');
     case 2:
-      return value.padRight(lenght + 2, '=');
+      return value.padRight(length + 2, '=');
     case 3:
-      return value.padRight(lenght + 1, '=');
+      return value.padRight(length + 1, '=');
     default:
       return value;
   }


### PR DESCRIPTION
## Description

Base64 requires 4 byte aligned strings to decode. Currently the `b64Padded` and `b64Unpadded` method in helpers which are used to decode JWT's without verification are missing the case of needing 3 padding bytes to be 4 byte aligned.

This PR adds that case and corrects a small typo.