### PR TITLE
Set parameters when using JWT.decode

### DIFF
--- a/lib/src/jwt.dart
+++ b/lib/src/jwt.dart
@@ -188,6 +188,9 @@ class JWT {
   }
 
   /// Decode a token without checking its signature
+  /// 
+  /// This also sets [JWT.audience], [JWT.subject], [JWT.issuer], and
+  /// [JWT.jwtId] even though they are not verified. Use with caution.
   static JWT decode(String token) {
     try {
       final parts = token.split('.');
@@ -207,6 +210,10 @@ class JWT {
         return JWT(
           payload,
           header: header,
+          audience: _parseAud(payload['aud']),
+          issuer: payload['iss']?.toString(),
+          subject: payload['sub']?.toString(),
+          jwtId: payload['jti']?.toString(),
         );
       }
     } catch (ex, stackTrace) {


### PR DESCRIPTION
I use the `JWT.decode` method quite often. I believe it is less resource intense (idk), and easier to implement, because you don't have to set all the check parameters.

One thing that's always getting on my nerves is that the function doesn't set the necessary attributes of the JWT object, which makes it harder to work with (arguably not much harder but harder nonetheless).

I'm not sure whether this is a brilliant idea or not. As far as I can tell, nothing should break, but there were no tests and I didn't want to write my own, so I couldn't really test. I added documentation though that lets devs know to use this values with caution as they are not checked.