### PR TITLE
fix: Require `header` to be a `Map` when decoding JWT

### DIFF
--- a/lib/src/jwt.dart
+++ b/lib/src/jwt.dart
@@ -197,7 +197,8 @@ class JWT {
   static JWT decode(String token) {
     try {
       final parts = token.split('.');
-      var header = jsonBase64.decode(base64Padded(parts[0]));
+      var header =
+          jsonBase64.decode(base64Padded(parts[0])) as Map<String, dynamic>;
 
       dynamic payload;
 
@@ -214,7 +215,7 @@ class JWT {
 
       return JWT(
         payload,
-        header: header is! Map<String, dynamic> ? null : header,
+        header: header,
         audience: audiance,
         issuer: issuer,
         subject: subject,

--- a/test/header_test.dart
+++ b/test/header_test.dart
@@ -147,5 +147,18 @@ void main() {
         });
       });
     });
+
+    group('invalid header', () {
+      test('invalid (non map) header should fail to decode', () {
+        final token =
+            'W10' + // base64 for `[]`, which can JSON decode but is not valid
+                '.eyJmb28iOiJiYXIifQ' +
+                '.'; // signature is not checked here
+
+        final jwt = JWT.tryDecode(token);
+
+        expect(jwt, isNull);
+      });
+    });
   });
 }


### PR DESCRIPTION
Even though the header's contents are not checked, they should match the minimal format (I suppose the spec requires an `alg`, but since we don't verify anything I did not enforce that).

It just seemed a bit tricky to "hide" (`null`) the header if it was not understood (especially since it already has to be base64 encoded JSON, it seemed unlikely that anything non-valid would be in there in the first place).